### PR TITLE
Enabled NOT operation

### DIFF
--- a/src/mol-plugin-state/transforms/model.ts
+++ b/src/mol-plugin-state/transforms/model.ts
@@ -786,7 +786,7 @@ const StructureSelectionFromScript = PluginStateTransform.BuiltIn({
     from: SO.Molecule.Structure,
     to: SO.Molecule.Structure,
     params: () => ({
-        script: PD.Script({ language: 'vmd', expression: 'all' }),
+        script: PD.Script({ language: 'pymol', expression: 'all' }),
         label: PD.Optional(PD.Text(''))
     })
 })({

--- a/src/mol-script/runtime/query/table.ts
+++ b/src/mol-script/runtime/query/table.ts
@@ -248,6 +248,9 @@ const symbols = [
     D(MolScript.structureQuery.generator.rings, function structureQuery_generator_rings(ctx, xs) {
         return Queries.generators.rings(xs?.['fingerprint']?.(ctx) as any, xs?.['only-aromatic']?.(ctx))(ctx);
     }),
+    D(MolScript.structureQuery.generator.queryInSelection, function structureQuery_generator_queryInSelection(ctx, xs) {
+        return Queries.generators.querySelection(xs[0] as any, xs['query'] as any, xs['in-complement'] as any)(ctx);
+    }),
 
     // ============= MODIFIERS ================
 

--- a/src/mol-script/transpilers/helper.ts
+++ b/src/mol-script/transpilers/helper.ts
@@ -195,8 +195,8 @@ export function testExpr(property: any, args: any) {
 
 export function invertExpr(selection: Expression) {
     return B.struct.generator.queryInSelection({
-        0: selection, query: B.struct.generator.atomGroups(), 'in-complement': true
-    });
+        0: selection, query: B.struct.generator.all(), 'in-complement': true}
+    );
 }
 
 export function strLenSortFn(a: string, b: string) {


### PR DESCRIPTION
`structure-query.generator.query-in-selection` was implemented in `src/mol-script/runtime/query/table.ts`: this enables NOT operation. In addition, `tranpiler/helper.ts` was fixed to use `B.struct.generator.all()` instead of `B.struct.generator.atomGroups()`. `B.struct.generator.atomGroups()` is not working for some reason, which was also met in the keyword 'all' in all of `vmd/pymol/jmol parser.ts`